### PR TITLE
 fix - some bugs (query event, timestamp, comment/enum types)

### DIFF
--- a/src/MySQLReplication/Event/QueryEvent.php
+++ b/src/MySQLReplication/Event/QueryEvent.php
@@ -24,7 +24,7 @@ class QueryEvent extends EventCommon
         $schema = $this->binaryDataReader->read($schema_length);
         $this->binaryDataReader->advance(1);
         $query = $this->binaryDataReader->read(
-            $this->eventInfo->getSize() - 36 - $status_vars_length - $schema_length - 1
+            $this->eventInfo->getSize() - 13 - $status_vars_length - $schema_length - 1
         );
 
         return new QueryDTO(

--- a/src/MySQLReplication/Event/RowEvent/RowEvent.php
+++ b/src/MySQLReplication/Event/RowEvent/RowEvent.php
@@ -351,6 +351,10 @@ class RowEvent extends EventCommon
             {
                 $values[$name] = $this->getDatetime2($column);
             }
+            elseif ($column['type'] == ConstFieldType::TIMESTAMP)
+			{
+				$values[$name] = date('c', $this->binaryDataReader->readUInt32());
+			}
             elseif ($column['type'] === ConstFieldType::TIME2)
             {
                 $values[$name] = $this->getTime2($column);

--- a/src/MySQLReplication/MySQLReplicationFactory.php
+++ b/src/MySQLReplication/MySQLReplicationFactory.php
@@ -75,6 +75,7 @@ class MySQLReplicationFactory
             'host' => $config->getIp(),
             'port' => $config->getPort(),
             'driver' => 'pdo_mysql',
+			'charset' => $config->getCharset() ? $config->getCharset() : 'utf8'
         ]);
         $this->binLogAuth = new BinLogAuth();
         $this->MySQLRepository = new MySQLRepository($this->connection);


### PR DESCRIPTION
Hello krowinski

I am newbie.

I found some simple bugs. (in mariadb-10.0.26) 

1. wrong calculation for query in query event
  cf) python-mysql-replication/blame/master/pymysqlreplication/event.py

2. support timestamp for column data  
   error: Unknown row type: 7

3. use db charset
   encoding problem form comment/enum types which include unicode.

thank you for reading :)
