### PR TITLE
fix correct binFileName in RotateEvent

### DIFF
--- a/src/MySQLReplication/Event/RotateEvent.php
+++ b/src/MySQLReplication/Event/RotateEvent.php
@@ -16,9 +16,7 @@ class RotateEvent  extends EventCommon
     public function makeRotateEventDTO()
     {
         $pos = $this->binaryDataReader->readUInt64();
-        $binFileName = $this->binaryDataReader->read(
-            $this->eventInfo->getSizeNoHeader() - 8
-        );
+        $binFileName = $this->binaryDataReader->read($this->eventInfo->getSizeNoHeader());
 
         return new RotateDTO(
             $this->eventInfo,


### PR DESCRIPTION
Hello krowinski

I found 1 bug in rotate Event. (in mariadb-10.0.26)

before:

=== Event rotate === 
Date: 1970-01-01T09:00:00+09:00
Log position: 0
Event size: 45
Binlog position: 4
**Binlog filename: mariadb-bin.00**

After patching:

=== Event rotate === 
Date: 1970-01-01T09:00:00+09:00
Log position: 0
Event size: 45
Binlog position: 4
Binlog filename: mariadb-bin.000002

my references are listed below
1. [https://dev.mysql.com/doc/internals/en/rotate-event.html]
2. https://github.com/shyiko/mysql-binlog-connector-java/blob/master/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/RotateEventDataDeserializer.java#L32
3. **[https://github.com/noplay/python-mysql-replication/blob/master/pymysqlreplication/event.py#L86]**

I don't know why python module has different logic. (maybe bug?)

double check please!

thank you for reading :)
