### PR TITLE
fix skip mode using tablesOnly and databasesOnly

### DIFF
--- a/src/MySQLReplication/Event/Event.php
+++ b/src/MySQLReplication/Event/Event.php
@@ -86,7 +86,10 @@ class Event
         );
 
         if (ConstEventType::TABLE_MAP_EVENT === $eventInfo->getType()) {
-            $this->eventDispatcher->dispatch(ConstEventsNames::TABLE_MAP, $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeTableMapDTO());
+			$event = $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeTableMapDTO();
+			if ($event !== null) {
+				$this->eventDispatcher->dispatch(ConstEventsNames::TABLE_MAP, $event);
+			}
         } else {
             if ([] !== $this->config->getEventsOnly() && !in_array($eventInfo->getType(), $this->config->getEventsOnly(), true)) {
                 return;
@@ -97,11 +100,20 @@ class Event
             }
 
             if (in_array($eventInfo->getType(), [ConstEventType::UPDATE_ROWS_EVENT_V1, ConstEventType::UPDATE_ROWS_EVENT_V2], true)) {
-                $this->eventDispatcher->dispatch(ConstEventsNames::UPDATE, $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeUpdateRowsDTO());
+				$event = $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeUpdateRowsDTO();
+				if ($event !== null) {
+					$this->eventDispatcher->dispatch(ConstEventsNames::UPDATE, $event);
+				}
             } elseif (in_array($eventInfo->getType(), [ConstEventType::WRITE_ROWS_EVENT_V1, ConstEventType::WRITE_ROWS_EVENT_V2], true)) {
-                $this->eventDispatcher->dispatch(ConstEventsNames::WRITE, $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeWriteRowsDTO());
+				$event = $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeWriteRowsDTO();
+				if ($event !== null) {
+					$this->eventDispatcher->dispatch(ConstEventsNames::WRITE, $event);
+				}
             } elseif (in_array($eventInfo->getType(), [ConstEventType::DELETE_ROWS_EVENT_V1, ConstEventType::DELETE_ROWS_EVENT_V2], true)) {
-                $this->eventDispatcher->dispatch(ConstEventsNames::DELETE, $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeDeleteRowsDTO());
+            	$event = $this->rowEventService->makeRowEvent($binaryDataReader, $eventInfo)->makeDeleteRowsDTO();
+            	if ($event !== null) {
+					$this->eventDispatcher->dispatch(ConstEventsNames::DELETE, $event);
+				}
             } elseif (ConstEventType::XID_EVENT === $eventInfo->getType()) {
                 $this->eventDispatcher->dispatch(ConstEventsNames::XID, (new XidEvent($eventInfo, $binaryDataReader))->makeXidDTO());
             } elseif (ConstEventType::ROTATE_EVENT === $eventInfo->getType()) {


### PR DESCRIPTION
Hello krowinski

I found another bug. 

**Below error happended** when I use tablesOnly or databasesOnly.

```
TypeError: Argument 1 passed to MySQLReplication\Event\EventSubscribers::onTableMap() must be an instance of MySQLReplication\Event\DTO\TableMapDTO, instance of Symfony\Component\EventDispatcher\Event given
#6 /platform/admin/vendor/krowinski/php-mysql-replication/src/MySQLReplication/Event/EventSubscribers.php(75): onTableMap
#5 [Anonymous function](0): call_user_func
#4 /platform/admin/vendor/symfony/event-dispatcher/EventDispatcher.php(174): doDispatch
#3 /platform/admin/vendor/symfony/event-dispatcher/EventDispatcher.php(43): dispatch
#2 /platform/admin/vendor/krowinski/php-mysql-replication/src/MySQLReplication/Event/Event.php(89): consume
```

If target event(tableMap,RowDto) is matched(tablesOnly, DatabasesOnly), null is returned by makeTableMapDTO.

https://github.com/krowinski/php-mysql-replication/blob/master/src/MySQLReplication/Event/Event.php#L89

and that null is replaced with default event in EventDispatcher(Symfony).
https://github.com/symfony/event-dispatcher/blob/master/EventDispatcher.php#L39
Finally typeError is happened.

Anyway I just fixed it but I think you have another good idea.

Thanks for reading and check my code.



