### PR TITLE
fix some bug fixes

### DIFF
--- a/src/MySQLReplication/BinLog/BinLogSocketConnect.php
+++ b/src/MySQLReplication/BinLog/BinLogSocketConnect.php
@@ -159,7 +159,8 @@ class BinLogSocketConnect
             $this->execute('SET @slave_connect_state = \'' . Config::getMariaDbGtid() . '\'');
             $this->execute('SET @slave_gtid_strict_mode = 0');
             $this->execute('SET @slave_gtid_ignore_duplicates = 0');
-        } else if ('' !== Config::getGtid()) {
+        }
+        if ('' !== Config::getGtid()) {
             $this->setBinLogDumpGtid();
         } else {
             $this->setBinLogDump();

--- a/src/MySQLReplication/Repository/MySQLRepository.php
+++ b/src/MySQLReplication/Repository/MySQLRepository.php
@@ -75,7 +75,13 @@ class MySQLRepository implements RepositoryInterface
     {
         $res = $this->getConnection()->fetchAssoc('SHOW GLOBAL VARIABLES LIKE "BINLOG_CHECKSUM"');
 
-        return isset($res['Value']);
+		if (!isset($res['Value'])) {
+			return false;
+		}
+
+		$check_sum = $res['Value'];
+
+		return (!empty($check_sum) && strtolower($check_sum) !== 'none');
     }
 
     /**


### PR DESCRIPTION
Hello krowinski

I found two bugs. (in mariadb-10.0.26)

1. BinlogSocketConnect refactoring error 
   -> mariadb is not working. so I fixed it.
   
2. Binlog_checksum 's result 
    I didn't use it but I found this problem. Just check below site.
    MySQL 5.6.2  --binlog-checksum={NONE|CRC32}
    https://dev.mysql.com/doc/refman/5.6/en/replication-options-binary-log.html
   
Thanks for reading and your new v3.0.0 release. :)
