### PR TITLE
fix sending more than 16MB <2>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ before_script:
   - "echo '[mysqld]'            | sudo tee /etc/mysql/conf.d/replication.cnf"
   - "echo 'log-bin=mysql-bin'   | sudo tee -a /etc/mysql/conf.d/replication.cnf"
   - "echo 'server-id=1'         | sudo tee -a /etc/mysql/conf.d/replication.cnf"
-  - "echo 'binlog-format = row' | sudo tee -a /etc/mysql/conf.d/replication.cnf"
+  - "echo 'binlog-format= row' | sudo tee -a /etc/mysql/conf.d/replication.cnf"
+  - "echo 'max_allowed_packet= 64M' | sudo tee -a /etc/mysql/conf.d/replication.cnf"
+  - "echo 'innodb_log_file_size= 250M' | sudo tee -a /etc/mysql/conf.d/replication.cnf"
   - "cat /etc/mysql/conf.d/replication.cnf"
 
   # Enable GTID (only for mysql 5.*)

--- a/src/MySQLReplication/BinLog/BinLogSocketConnect.php
+++ b/src/MySQLReplication/BinLog/BinLogSocketConnect.php
@@ -85,7 +85,7 @@ class BinLogSocketConnect
 
         $result = $this->socket->readFromSocket($dataLength);
         if (true === $checkResponse) {
-            $this->isWriteSuccessful($result, $isMaxDataLength);
+            $this->isWriteSuccessful($result);
         }
 
         //https://dev.mysql.com/doc/internals/en/sending-more-than-16mbyte.html
@@ -96,11 +96,7 @@ class BinLogSocketConnect
             }
             $dataLength = unpack('L', $header[0] . $header[1] . $header[2] . chr(0))[1];
             $isMaxDataLength = $dataLength === $this->binaryDataMaxLength;
-
             $next_result = $this->socket->readFromSocket($dataLength);
-            if (true === $checkResponse) {
-                $this->isWriteSuccessful($next_result, $isMaxDataLength);
-            }
             $result .= $next_result;
         }
 
@@ -109,15 +105,11 @@ class BinLogSocketConnect
 
     /**
      * @param string $data
-     * @param bool   $isMaxDataLength
      *
      * @throws BinLogException
      */
-    private function isWriteSuccessful($data, $isMaxDataLength = false)
+    private function isWriteSuccessful($data)
     {
-        if ($isMaxDataLength) {
-            return;
-        }
         $head = ord($data[0]);
         if (!in_array($head, $this->packageOkHeader, true)) {
             $errorCode = unpack('v', $data[1] . $data[2])[1];

--- a/tests/Integration/TypesTest.php
+++ b/tests/Integration/TypesTest.php
@@ -624,11 +624,11 @@ class TypesTest extends BaseTest
         for ($i = 0; $i < 40000000; $i++) {
             $long_text_data .= 'a';
         }
-        $create_query = "CREATE TABLE test (data LONGTEXT)";
-        $insert_query = "INSERT INTO test (data) VALUES ({$long_text_data})";
+        $create_query = "CREATE TABLE test (data LONGTEXT);";
+        $insert_query = "INSERT INTO test (data) VALUES ('{$long_text_data}')";
         $event = $this->createAndInsertValue($create_query, $insert_query);
 
-        self::assertEquals(strlen($long_text_data), strlen($event->getValues()[0]['test']));
+        self::assertEquals(strlen($long_text_data), strlen($event->getValues()[0]['data']));
     }
 
     /**

--- a/tests/Integration/TypesTest.php
+++ b/tests/Integration/TypesTest.php
@@ -614,6 +614,24 @@ class TypesTest extends BaseTest
     }
 
     /**
+     * https://dev.mysql.com/doc/internals/en/mysql-packet.html
+     * https://dev.mysql.com/doc/internals/en/sending-more-than-16mbyte.html
+     * @test
+     */
+    public function shouldBeLongerTextThan16Mb()
+    {
+        $long_text_data = '';
+        for ($i = 0; $i < 40000000; $i++) {
+            $long_text_data .= 'a';
+        }
+        $create_query = "CREATE TABLE test (data LONGTEXT)";
+        $insert_query = "INSERT INTO test (data) VALUES ({$long_text_data})";
+        $event = $this->createAndInsertValue($create_query, $insert_query);
+
+        self::assertEquals(strlen($long_text_data), strlen($event->getValues()[0]['test']));
+    }
+
+    /**
      * @test
      */
     public function shouldBeBlob()


### PR DESCRIPTION
Hello Krowinski
I am sorry for my previous patch.
Because I found my misunderstanding about divided packets.
There is only one binlog event header for divided packets.
Please check my CODE or my explain below 
and then you may get it.

---
This is MySQL Internals Manual: `Sending More Than 16Mbytes` 
https://dev.mysql.com/doc/internals/en/mysql-packet.html
```
If a MySQL client or server wants to send data, it:
- Splits the data into packets of size (2^24−1) bytes
- Prepends to each chunk a packet header
```

These are 3 divided packets for Insert Statement with 40Mb field in my test.
```
header<int(3)> + sequence<int(1)> + payload including binlog event header<string(16,777,215)> +
header<int(3)> + sequence<int(1)> + payload<string(16,777,215)> +
header<int(3)> + sequence<int(1)> + payload<string(6,445,616)>
```

This is my test environment:
- mariadb-10.0.27
- https://github.com/kobi97/php-binlog-collector/blob/improve/change_test_environment_for_test_more_than_16mega_bytes/demo/Resources/tools/generate_test_sql.php#L179


Thank for reading :)