### PR TITLE
support testcase for mariadb-10.0, 10-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ matrix:
         - DB=mariadb:5.5
       php: "7.1"
     - env:
+        - DB=mariadb:10.0
+      php: "7.1"
+    - env:
+        - DB=mariadb:10.1
+      php: "7.1"
+    - env:
         - DB=mysql:5.5
       php: "7.1"
     - env:
@@ -32,6 +38,12 @@ matrix:
       php: "7.1"
     - env:
         - DB=mariadb:5.5
+      php: "7.2"
+    - env:
+        - DB=mariadb:10.0
+      php: "7.2"
+    - env:
+        - DB=mariadb:10.1
       php: "7.2"
     - env:
         - DB=mysql:5.5

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Compatibility (based on integration tests)
  - mysql 5.7
  - mysql 8.0 (ONLY with mysql_native_password)
  - mariadb 5.5
- - mariadb 10.0 (partaily, problem with some cases of TIMESTAMP)
+ - mariadb 10.0
+ - mariadb 10.1
  - probably percona versions as is based on native mysql
 
 MySQL server settings

--- a/tests/Integration/TypesTest.php
+++ b/tests/Integration/TypesTest.php
@@ -268,7 +268,14 @@ class TypesTest extends BaseTest
      */
     public function shouldBeTimestampMySQL56(): void
     {
-        if ($this->checkForVersion(5.6)) {
+        /*
+         * https://mariadb.com/kb/en/library/microseconds-in-mariadb/
+         * MySQL 5.6 introduced microseconds using a slightly different implementation to MariaDB 5.3.
+         * Since MariaDB 10.1, MariaDB has defaulted to the MySQL format ...
+         */
+        if (BinLogServerInfo::isMariaDb() && $this->checkForVersion(10.1)) {
+            $this->markTestIncomplete('Only for mariadb 10.1 or higher');
+        } elseif ($this->checkForVersion(5.6)) {
             $this->markTestIncomplete('Only for mysql 5.6 or higher');
         }
 


### PR DESCRIPTION
Hi krowinski

Since I have been using your php-mysql-replication library in my mariadb-10.0 and 10.1,
I patched your testcase available for your library as well.

Please, check! 

p.s. I found FileRotate Event bug in mariadb-10.2, so I will give you PR later.

Rgds,