### PR TITLE
fix: use provided event dispatcher

### DIFF
--- a/src/MySQLReplication/MySQLReplicationFactory.php
+++ b/src/MySQLReplication/MySQLReplicationFactory.php
@@ -66,9 +66,9 @@ class MySQLReplicationFactory
         if (null === $cache) {
             $cache = new ArrayCache();
         }
-        if (null === $eventDispatcher) {
-            $this->eventDispatcher = new EventDispatcher();
-        }
+
+        $this->eventDispatcher = $eventDispatcher ?: new EventDispatcher();
+
         if (null === $socket) {
             $socket = new Socket();
         }


### PR DESCRIPTION
Before the fix, an error occurred:
```
TypeError: Argument 3 passed to MySQLReplication\Event\Event::__construct() must be an instance of Symfony\Component\EventDispatcher\EventDispatcher, null given, called
```

Because `Event` class is instanciated with property `$this->eventDispatcher` but was only initialised when `null` is used in the constructor of `MySQLReplicationFactory`.