### PR TITLE
fix: change for event dispatcher interface to keep logic from MySQLReplicationFactory

### DIFF
--- a/src/MySQLReplication/Event/Event.php
+++ b/src/MySQLReplication/Event/Event.php
@@ -20,7 +20,7 @@ use MySQLReplication\JsonBinaryDecoder\JsonBinaryDecoderException;
 use MySQLReplication\Socket\SocketException;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Event
 {
@@ -35,7 +35,7 @@ class Event
     public function __construct(
         BinLogSocketConnect $binLogSocketConnect,
         RowEventFactory $rowEventFactory,
-        EventDispatcher $eventDispatcher,
+        EventDispatcherInterface $eventDispatcher,
         CacheInterface $cache
     ) {
         $this->binLogSocketConnect = $binLogSocketConnect;


### PR DESCRIPTION
It is useful to keep the same logic with `EventDispatcherInterface` in `Event` class because it is this interface for `MySQLReplicationFactory` class. It prevents this error for example:

```
Argument 3 passed to MySQLReplication\Event\Event::__construct() must be an instance of Symfony\Component\EventDispatcher\EventDispatcher, instance of Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher given
```