### PR TITLE
fix: change type from int to float for heartbeat period

### DIFF
--- a/src/MySQLReplication/Config/Config.php
+++ b/src/MySQLReplication/Config/Config.php
@@ -42,7 +42,7 @@ class Config implements JsonSerializable
         array $databasesOnly,
         int $tableCacheSize,
         array $custom,
-        int $heartbeatPeriod
+        float $heartbeatPeriod
     ) {
         self::$user = $user;
         self::$host = $host;
@@ -103,8 +103,8 @@ class Config implements JsonSerializable
                 ConfigException::TABLE_CACHE_SIZE_ERROR_MESSAGE, ConfigException::TABLE_CACHE_SIZE_ERROR_CODE
             );
         }
-        if (0 !== self::$heartbeatPeriod && false === filter_var(
-                self::$heartbeatPeriod, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 4294967]]
+        if (0.0 !== self::$heartbeatPeriod && false === (
+                self::$heartbeatPeriod >= 0.001 && self::$heartbeatPeriod <= 4294967.0
             )) {
             throw new ConfigException(
                 ConfigException::HEARTBEAT_PERIOD_ERROR_MESSAGE, ConfigException::HEARTBEAT_PERIOD_ERROR_CODE
@@ -215,7 +215,7 @@ class Config implements JsonSerializable
         return self::$eventsIgnore;
     }
 
-    public static function getHeartbeatPeriod(): int
+    public static function getHeartbeatPeriod(): float
     {
         return self::$heartbeatPeriod;
     }

--- a/src/MySQLReplication/Config/ConfigBuilder.php
+++ b/src/MySQLReplication/Config/ConfigBuilder.php
@@ -21,7 +21,7 @@ class ConfigBuilder
     private $mariaDbGtid = '';
     private $tableCacheSize = 128;
     private $custom = [];
-    private $heartbeatPeriod = 0;
+    private $heartbeatPeriod = 0.0;
 
     public function withUser(string $user): self
     {
@@ -140,7 +140,7 @@ class ConfigBuilder
     /**
      * @see https://dev.mysql.com/doc/refman/5.6/en/change-master-to.html
      */
-    public function withHeartbeatPeriod(int $heartbeatPeriod): self
+    public function withHeartbeatPeriod(float $heartbeatPeriod): self
     {
         $this->heartbeatPeriod = $heartbeatPeriod;
 

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -125,6 +125,29 @@ class ConfigTest extends BaseTest
         self::assertFalse(Config::checkEvent(4));
     }
 
+    public function shouldCheckHeartbeatPeriodProvider(): array
+    {
+        return [
+            [0],
+            [0.0],
+            [0.001],
+            [4294967],
+            [2],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider shouldCheckHeartbeatPeriodProvider
+     */
+    public function shouldCheckHeartbeatPeriod($heartbeatPeriod): void
+    {
+        $config = (new ConfigBuilder())->withHeartbeatPeriod($heartbeatPeriod)->build();
+        $config::validate();
+
+        self::assertSame((float) $heartbeatPeriod, $config::getHeartbeatPeriod());
+    }
+
     public function shouldValidateProvider(): array
     {
         return [


### PR DESCRIPTION
According to the [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/change-master-to.html), the heartbeat period configuration permits to have a float type:
```
The heartbeat interval interval is a decimal value having the range 0 to 4294967 seconds and a resolution in milliseconds; the smallest nonzero value is 0.001.
```