### PR TITLE
Preserve threadId in QUERY_EVENT.

### DIFF
--- a/src/MySQLReplication/Event/DTO/QueryDTO.php
+++ b/src/MySQLReplication/Event/DTO/QueryDTO.php
@@ -12,18 +12,21 @@ class QueryDTO extends EventDTO
     private $query;
     private $database;
     private $type = ConstEventsNames::QUERY;
+    private $threadId;
 
     public function __construct(
         EventInfo $eventInfo,
         string $database,
         int $executionTime,
-        string $query
+        string $query,
+        int $threadId
     ) {
         parent::__construct($eventInfo);
 
         $this->executionTime = $executionTime;
         $this->query = $query;
         $this->database = $database;
+        $this->threadId = $threadId;
     }
 
     public function getDatabase(): string
@@ -44,6 +47,11 @@ class QueryDTO extends EventDTO
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getThreadId(): int
+    {
+        return $this->threadId;
     }
 
     public function __toString(): string

--- a/src/MySQLReplication/Event/QueryEvent.php
+++ b/src/MySQLReplication/Event/QueryEvent.php
@@ -12,7 +12,7 @@ class QueryEvent extends EventCommon
 {
     public function makeQueryDTO(): QueryDTO
     {
-        $this->binaryDataReader->advance(4);
+        $threadId = $this->binaryDataReader->readUInt32();
         $executionTime = $this->binaryDataReader->readUInt32();
         $schemaLength = $this->binaryDataReader->readUInt8();
         $this->binaryDataReader->advance(2);
@@ -26,7 +26,8 @@ class QueryEvent extends EventCommon
             $this->eventInfo,
             $schema,
             $executionTime,
-            $query
+            $query,
+            $threadId
         );
     }
 }


### PR DESCRIPTION
This patch preserves `threadId` found in QUERY_EVENT. Thread id is useful for audits.