### PR TITLE
Update and extend links to mysql documentation

### DIFF
--- a/src/MySQLReplication/Definitions/ConstEventType.php
+++ b/src/MySQLReplication/Definitions/ConstEventType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MySQLReplication\Definitions;
 
 /**
- * @see https://dev.mysql.com/doc/internals/en/event-classes-and-types.html
+ * @see https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/libs/mysql/binlog/event/binlog_event.h#L285 (MySQL binlog_event.h)
  */
 enum ConstEventType: int
 {

--- a/src/MySQLReplication/Event/Event.php
+++ b/src/MySQLReplication/Event/Event.php
@@ -37,7 +37,7 @@ readonly class Event
     {
         $binaryDataReader = new BinaryDataReader($this->binLogSocketConnect->getResponse());
 
-        // check EOF_Packet -> https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html
+        // check EOF_Packet -> https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_eof_packet.html
         if ($binaryDataReader->readUInt8() === self::EOF_HEADER_VALUE) {
             return;
         }
@@ -127,6 +127,9 @@ readonly class Event
         return null;
     }
 
+    /**
+     * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_binlog_event_header
+     */
     private function createEventInfo(BinaryDataReader $binaryDataReader): EventInfo
     {
         return new EventInfo(

--- a/src/MySQLReplication/Event/QueryEvent.php
+++ b/src/MySQLReplication/Event/QueryEvent.php
@@ -7,7 +7,7 @@ namespace MySQLReplication\Event;
 use MySQLReplication\Event\DTO\QueryDTO;
 
 /**
- * @see https://dev.mysql.com/doc/internals/en/query-event.html
+ * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_event_query
  */
 class QueryEvent extends EventCommon
 {

--- a/src/MySQLReplication/Event/RotateEvent.php
+++ b/src/MySQLReplication/Event/RotateEvent.php
@@ -7,7 +7,7 @@ namespace MySQLReplication\Event;
 use MySQLReplication\Event\DTO\RotateDTO;
 
 /**
- * @see https://dev.mysql.com/doc/internals/en/rotate-event.html
+ * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_event_rotate
  */
 class RotateEvent extends EventCommon
 {

--- a/src/MySQLReplication/Event/XidEvent.php
+++ b/src/MySQLReplication/Event/XidEvent.php
@@ -6,6 +6,9 @@ namespace MySQLReplication\Event;
 
 use MySQLReplication\Event\DTO\XidDTO;
 
+/**
+ * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_event_xid
+ */
 class XidEvent extends EventCommon
 {
     public function makeXidDTO(): XidDTO


### PR DESCRIPTION
I have updated some of the documentation links because they ended at the start page of the MySQL Source Code Documentation. 

For the `ConstEventType` i linked directly to the mysql github repository because the documentation itself seemed not to allow the direct link to the list. 

For some links in the project, like the "Event Meanings" in the Readme and the EventDTO class i did not found a corresponding page. I do not know what the original page contained so ... i left them but maybe an update here would also be nice in the future.