### PR TITLE
Implement rows query event

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Start mysql service
         run: |
-          echo -e "\n[mysqld]\nserver-id=1\nbinlog_format=row\nlog_bin=/var/log/mysql/mysql-bin.log" | sudo tee -a /etc/mysql/my.cnf
+          echo -e "\n[mysqld]\nserver-id=1\nbinlog_format=row\nlog_bin=/var/log/mysql/mysql-bin.log\nbinlog_rows_query_log_events=ON" | sudo tee -a /etc/mysql/my.cnf
           sudo /etc/init.d/mysql start
           mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql -proot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       '--log_bin=binlog',
       '--max_binlog_size=8M',
       '--binlog_format=row',
-      '--server-id=1'
+      '--server-id=1',
+      '--binlog_rows_query_log_events=ON'
     ]
     environment:
       - MYSQL_ROOT_PASSWORD=root

--- a/src/MySQLReplication/Definitions/ConstEventsNames.php
+++ b/src/MySQLReplication/Definitions/ConstEventsNames.php
@@ -17,4 +17,5 @@ enum ConstEventsNames: string
     case TABLE_MAP = 'tableMap';
     case WRITE = 'write';
     case FORMAT_DESCRIPTION = 'format description';
+    case ROWS_QUERY = 'rows_query';
 }

--- a/src/MySQLReplication/Event/DTO/RowsQueryDTO.php
+++ b/src/MySQLReplication/Event/DTO/RowsQueryDTO.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySQLReplication\Event\DTO;
+
+use MySQLReplication\Definitions\ConstEventsNames;
+use MySQLReplication\Event\EventInfo;
+
+class RowsQueryDTO extends EventDTO
+{
+    private ConstEventsNames $type = ConstEventsNames::ROWS_QUERY;
+
+    public function __construct(
+        EventInfo $eventInfo,
+        public readonly string $query,
+    ) {
+        parent::__construct($eventInfo);
+    }
+
+    public function __toString(): string
+    {
+        return PHP_EOL .
+            '=== Event ' . $this->getType() . ' === ' . PHP_EOL .
+            'Date: ' . $this->eventInfo->getDateTime() . PHP_EOL .
+            'Log position: ' . $this->eventInfo->pos . PHP_EOL .
+            'Event size: ' . $this->eventInfo->size . PHP_EOL .
+            'Query: ' . $this->query . PHP_EOL;
+    }
+
+    public function getType(): string
+    {
+        return $this->type->value;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/MySQLReplication/Event/Event.php
+++ b/src/MySQLReplication/Event/Event.php
@@ -120,6 +120,11 @@ readonly class Event
             );
         }
 
+        // The Rows Query Log Event will be triggered with enabled MySQL Config `binlog_rows_query_log_events`
+        if ($eventInfo->type === ConstEventType::ROWS_QUERY_LOG_EVENT->value) {
+            return (new RowsQueryEvent($eventInfo, $binaryDataReader, $this->binLogServerInfo))->makeRowsQueryDTO();
+        }
+
         if ($eventInfo->type === ConstEventType::FORMAT_DESCRIPTION_EVENT->value) {
             return new FormatDescriptionEventDTO($eventInfo);
         }

--- a/src/MySQLReplication/Event/EventSubscribers.php
+++ b/src/MySQLReplication/Event/EventSubscribers.php
@@ -13,6 +13,7 @@ use MySQLReplication\Event\DTO\HeartbeatDTO;
 use MySQLReplication\Event\DTO\MariaDbGtidLogDTO;
 use MySQLReplication\Event\DTO\QueryDTO;
 use MySQLReplication\Event\DTO\RotateDTO;
+use MySQLReplication\Event\DTO\RowsQueryDTO;
 use MySQLReplication\Event\DTO\TableMapDTO;
 use MySQLReplication\Event\DTO\UpdateRowsDTO;
 use MySQLReplication\Event\DTO\WriteRowsDTO;
@@ -35,6 +36,7 @@ class EventSubscribers implements EventSubscriberInterface
             ConstEventsNames::MARIADB_GTID->value => 'onMariaDbGtid',
             ConstEventsNames::FORMAT_DESCRIPTION->value => 'onFormatDescription',
             ConstEventsNames::HEARTBEAT->value => 'onHeartbeat',
+            ConstEventsNames::ROWS_QUERY->value => 'onRowsQuery',
         ];
     }
 
@@ -89,6 +91,11 @@ class EventSubscribers implements EventSubscriberInterface
     }
 
     public function onHeartbeat(HeartbeatDTO $event): void
+    {
+        $this->allEvents($event);
+    }
+
+    public function onRowsQuery(RowsQueryDTO $event): void
     {
         $this->allEvents($event);
     }

--- a/src/MySQLReplication/Event/RowsQueryEvent.php
+++ b/src/MySQLReplication/Event/RowsQueryEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySQLReplication\Event;
+
+use MySQLReplication\Event\DTO\RowsQueryDTO;
+
+/**
+ * The Rows_query event is within the binary log when the MySQL Option `binlog_rows_query_log_events`
+ * is enabled.
+ *
+ * @see https://dev.mysql.com/doc/dev/mysql-server/latest/classRows__query__log__event.html
+ */
+class RowsQueryEvent extends EventCommon
+{
+    public function makeRowsQueryDTO(): RowsQueryDTO
+    {
+        // $this->binaryDataReader->advance(1);
+        return new RowsQueryDTO(
+            $this->eventInfo,
+            $this->binaryDataReader->read($this->binaryDataReader->readInt8()),
+        );
+    }
+}

--- a/tests/Integration/BaseCase.php
+++ b/tests/Integration/BaseCase.php
@@ -41,7 +41,7 @@ abstract class BaseCase extends TestCase
             ->withHost('0.0.0.0')
             ->withPassword('root')
             ->withPort(3306)
-            ->withEventsIgnore([ConstEventType::GTID_LOG_EVENT->value]);
+            ->withEventsIgnore($this->getIgnoredEvents());
 
         $this->connect();
 
@@ -81,6 +81,14 @@ abstract class BaseCase extends TestCase
         $this->connection->executeStatement('CREATE DATABASE ' . $this->database);
         $this->connection->executeStatement('USE ' . $this->database);
         $this->connection->executeStatement('SET SESSION sql_mode = \'\';');
+    }
+
+    protected function getIgnoredEvents(): array
+    {
+        return [
+            ConstEventType::GTID_LOG_EVENT->value, // Generally in here
+            ConstEventType::ROWS_QUERY_LOG_EVENT->value, // Just debugging, there is a special test for it
+        ];
     }
 
     protected function getEvent(): EventDTO


### PR DESCRIPTION
Sometimes there is a usage for the optional binlog event `Rows_query`. It contains the original query that triggered other events that change something within the database. It is a "logging" mechanism of MySQL. So by enabling `binlog_rows_query_log_events` within the MySQL Settings those events will be stored to the database. 

With the enabled option the Binlog for a single update query would look like

```
mysql-bin.000006	2105    Query	                1	       2178	        BEGIN
mysql-bin.000006	2178    Rows_query	        1	       2423	        # /*foo:bar;*/ UPDATE `test` SET foo = 'Foo Bar' WHERE id = 1
mysql-bin.000006	2423    Table_map	        1	       2530	        table_id: 109 (test.test)
mysql-bin.000006	2530    Update_rows	        1	       2950	        table_id: 109 flags: STMT_END_F
mysql-bin.000006	2950    Xid	                1	       2981	        COMMIT /* xid=4779 */
```

So the query does allow additional additional information for a change. In MariaDB the event is named `Annotate_Rows` with a different type identifier and so can be surely implemented later if someone needs it. 

For more information:

* https://dev.mysql.com/doc/dev/mysql-server/latest/classRows__query__log__event.html