### PR TITLE
Symfony Backward Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "doctrine/dbal": "^3.8",
     "psr/log": "^3.0",
     "psr/simple-cache": "^3.0",
-    "symfony/dependency-injection": "^7.0",
     "symfony/event-dispatcher": "^7.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "doctrine/dbal": "^3.8",
     "psr/log": "^3.0",
     "psr/simple-cache": "^3.0",
-    "symfony/event-dispatcher": "^7.0"
+    "symfony/event-dispatcher": "^6.0|^7.0"
   },
   "require-dev": {
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.19",


### PR DESCRIPTION
With the update to the current library version i did not see any change that would require to not support symfony in version 6. So i would appreciate it if we could move back a step and let the package be clear about what it needs. 

So i have removed the symfony di component because it is unsued in the library.
I have enabled symfony event dispatcher in version 6 beside the version 7 because there was no change that requires to not support older versions of this component.