### PR TITLE
Fix ROWS_QUERY event parsing long queries

### DIFF
--- a/src/MySQLReplication/Event/RowsQueryEvent.php
+++ b/src/MySQLReplication/Event/RowsQueryEvent.php
@@ -16,10 +16,10 @@ class RowsQueryEvent extends EventCommon
 {
     public function makeRowsQueryDTO(): RowsQueryDTO
     {
-        // $this->binaryDataReader->advance(1);
+        $this->binaryDataReader->advance(1);
         return new RowsQueryDTO(
             $this->eventInfo,
-            $this->binaryDataReader->read($this->binaryDataReader->readInt8()),
+            $this->binaryDataReader->read($this->eventInfo->getSizeNoHeader() - 1),
         );
     }
 }

--- a/tests/Integration/RowsQueryTest.php
+++ b/tests/Integration/RowsQueryTest.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace MySQLReplication\Tests\Integration;
 
+use Generator;
 use MySQLReplication\Definitions\ConstEventType;
 use MySQLReplication\Event\DTO\QueryDTO;
 use MySQLReplication\Event\DTO\RowsQueryDTO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class RowsQueryTest extends BaseCase
 {
-    public function testThatTheEditingQueryIsReadFromBinLog(): void
+    #[DataProvider('provideQueries')]
+    public function testThatTheEditingQueryIsReadFromBinLog(string $query): void
     {
         $this->connection->executeStatement(
             'CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))'
         );
 
-        $insertQuery = 'INSERT INTO test (data) VALUES(\'Hello\') /* Foo:Bar; */';
-        $this->connection->executeStatement($insertQuery);
+        $this->connection->executeStatement($query);
 
         // The Create Table Query ... irrelevant content for this test
         self::assertInstanceOf(QueryDTO::class, $this->getEvent());
@@ -26,7 +28,15 @@ final class RowsQueryTest extends BaseCase
 
         $rowsQueryEvent = $this->getEvent();
         self::assertInstanceOf(RowsQueryDTO::class, $rowsQueryEvent);
-        self::assertSame($insertQuery, $rowsQueryEvent->query);
+        self::assertSame($query, $rowsQueryEvent->query);
+    }
+
+    public static function provideQueries(): Generator
+    {
+        yield 'Short Query' => ['INSERT INTO test (data) VALUES(\'Hello\') /* Foo:Bar; */'];
+
+        $comment = '/* Foo:Bar; Bar:Baz; Baz:Quo; Quo:Foo; Quo:Foo; Quo:Foo; Quo:Foo; Foo:Baz; */';
+        yield 'Extra Long Query' => [$comment . ' INSERT INTO test (data) VALUES(\'Hello\') ' . $comment];
     }
     
     protected function getIgnoredEvents(): array


### PR DESCRIPTION
The event is containing an integer value of the length of the query which can be longer then first expected. This is not working with extra long queries. The test i had added with #112 had only a short query were it worked well. Because of the dynamic length of the query to catch also those i now utilize the header length of the full binlog event to get the query. 

Also i added a testcase for this with an extra long query. 

Hope this fits you @krowinski ... thanks for your time! 