### PR TITLE
Utilize matrix for texting multiple mysql versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,21 +2,21 @@ name: PHP Tests
 on: [push, pull_request]
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
+    strategy:
+        matrix:
+            php: [ '8.2' ]
+            mysql-version: [ '5.7', '8.0', '8.4' ]
 
     services:
       mysql:
-        image: mysql:5.7
+        image: "mysql:${{ matrix.mysql-version }}"
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: mysqlreplication_test
         ports:
           - 3306/tcp
-
-    strategy:
-      matrix:
-        php: [ '8.2' ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Hey @krowinski - you mentioned it is relevant to check mutliple mysql versions. So i have extended the workflow of the repositories test with a mysql testing matrix. Hope it fits your thoughts. 

Surely it can be extended in the future with a second CI Pipeline for MariaDB? But as a first throw ... what are you thinking?