### PR TITLE
feat: Add regular expression matching support for `checkDatabasesOnly` or `checkTablesOnly`

### DIFF
--- a/src/MySQLReplication/Config/Config.php
+++ b/src/MySQLReplication/Config/Config.php
@@ -27,6 +27,8 @@ readonly class Config implements JsonSerializable
         public array $custom,
         public float $heartbeatPeriod,
         public string $slaveUuid,
+        private array $tablesRegex = [],
+        private array $databasesRegex = [],
     ) {
     }
 
@@ -103,13 +105,26 @@ readonly class Config implements JsonSerializable
 
     public function checkDataBasesOnly(string $database): bool
     {
-        return $this->databasesOnly !== [] && !in_array($database, $this->databasesOnly, true);
+        return ($this->databasesOnly !== [] && !in_array($database, $this->databasesOnly, true))
+            || ($this->databasesRegex !== []  && !self::matchNames($database, $this->databasesRegex));
     }
 
 
     public function checkTablesOnly(string $table): bool
     {
-        return $this->tablesOnly !== [] && !in_array($table, $this->tablesOnly, true);
+        return ($this->tablesOnly !== [] && !in_array($table, $this->tablesOnly, true))
+            || ($this->tablesRegex !== [] && !self::matchNames($table, $this->tablesRegex));
+    }
+
+    private static function matchNames(string $name, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $name)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function checkEvent(int $type): bool

--- a/src/MySQLReplication/Config/ConfigBuilder.php
+++ b/src/MySQLReplication/Config/ConfigBuilder.php
@@ -32,6 +32,10 @@ class ConfigBuilder
 
     private array $databasesOnly = [];
 
+    private array $tablesRegex = [];
+
+    private array $databasesRegex = [];
+
     private string $mariaDbGtid = '';
 
     private int $tableCacheSize = 128;
@@ -143,6 +147,18 @@ class ConfigBuilder
         return $this;
     }
 
+    public function withDatabasesRegex(array $databasesRegex): self
+    {
+        $this->databasesRegex = $databasesRegex;
+        return $this;
+    }
+
+    public function withTablesRegex(array $tablesRegex): self
+    {
+        $this->tablesRegex = $tablesRegex;
+        return $this;
+    }
+
     public function withMariaDbGtid(string $mariaDbGtid): self
     {
         $this->mariaDbGtid = $mariaDbGtid;
@@ -194,7 +210,9 @@ class ConfigBuilder
             $this->tableCacheSize,
             $this->custom,
             $this->heartbeatPeriod,
-            $this->slaveUuid
+            $this->slaveUuid,
+            $this->tablesRegex,
+            $this->databasesRegex,
         );
     }
 }

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -97,6 +97,9 @@ class ConfigTest extends TestCase
 
         $config = (new ConfigBuilder())->withDatabasesOnly(['foo'])->build();
         self::assertTrue($config->checkDataBasesOnly('bar'));
+
+        $config = (new ConfigBuilder())->withDatabasesRegex(['/^foo_.*/'])->build();
+        self::assertFalse($config->checkDataBasesOnly('foo_123'));
     }
 
     public function testShouldCheckTablesOnly(): void
@@ -112,6 +115,9 @@ class ConfigTest extends TestCase
 
         $config = (new ConfigBuilder())->withTablesOnly(['foo'])->build();
         self::assertTrue($config->checkTablesOnly('bar'));
+
+        $config = (new ConfigBuilder())->withTablesRegex(['/^foo_.*/'])->build();
+        self::assertFalse($config->checkTablesOnly('foo_123'));
     }
 
     public function testShouldCheckEvent(): void


### PR DESCRIPTION

```php
$config = (new ConfigBuilder())->withTablesRegex(['/^foo_.*/'])->build();
self::assertFalse($config->checkTablesOnly('foo_123'));
```

