### PR TITLE
chore: deprecation constructor argument must explicit nullable

### DIFF
--- a/src/MySQLReplication/MySQLReplicationFactory.php
+++ b/src/MySQLReplication/MySQLReplicationFactory.php
@@ -33,11 +33,11 @@ class MySQLReplicationFactory
 
     public function __construct(
         Config $config,
-        RepositoryInterface $repository = null,
-        CacheInterface $cache = null,
-        EventDispatcherInterface $eventDispatcher = null,
-        SocketInterface $socket = null,
-        LoggerInterface $logger = null
+        ?RepositoryInterface $repository = null,
+        ?CacheInterface $cache = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?SocketInterface $socket = null,
+        ?LoggerInterface $logger = null
     ) {
         $config->validate();
 


### PR DESCRIPTION
With PHP 8.4 setting arguments with default null value not explicit nullable is deprecated.

```
Deprecated: MySQLReplication\MySQLReplicationFactory::__construct(): Implicitly marking parameter $repository as nullable is deprecated, the explicit nullable type must be used instead in /opt/app/vendor/krowinski/php-mysql-replication/src/MySQLReplication/MySQLReplicationFactory.php on line 34
```