### PR TITLE
Run tests with multiple php and mysql versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,27 +6,25 @@ jobs:
 
     strategy:
         matrix:
-            php: [ '8.2' ]
+            php: [ '8.2', '8.3', '8.4' ]
             mysql-version: [ '5.7', '8.0', '8.4' ]
-
-    services:
-      mysql:
-        image: "mysql:${{ matrix.mysql-version }}"
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: mysqlreplication_test
-        ports:
-          - 3306/tcp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Start mysql service
-        run: |
-          echo -e "\n[mysqld]\nserver-id=1\nbinlog_format=row\nlog_bin=/var/log/mysql/mysql-bin.log\nbinlog_rows_query_log_events=ON" | sudo tee -a /etc/mysql/my.cnf
-          sudo /etc/init.d/mysql start
-          mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql -proot
+      - uses: shogo82148/actions-setup-mysql@v1
+        with:
+          mysql-version: "${{ matrix.mysql-version }}"
+          my-cnf: |
+            server-id=1
+            binlog_format=row
+            binlog_rows_query_log_events=ON
+            log_bin=binlog
+          root-password: root
+
+      - name: set up timezones
+        run: mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql -proot
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
@@ -39,7 +37,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}

--- a/src/MySQLReplication/Repository/MySQLRepository.php
+++ b/src/MySQLReplication/Repository/MySQLRepository.php
@@ -70,8 +70,14 @@ readonly class MySQLRepository implements RepositoryInterface, PingableConnectio
 
     public function getMasterStatus(): MasterStatusDTO
     {
+        $query = 'SHOW MASTER STATUS';
+
+        if (str_starts_with($this->getVersion(), '8.4')) {
+            $query = 'SHOW BINARY LOG STATUS';
+        }
+
         $data = $this->getConnection()
-            ->fetchAssociative('SHOW MASTER STATUS');
+            ->fetchAssociative($query);
         if (empty($data)) {
             throw new BinLogException(
                 MySQLReplicationException::BINLOG_NOT_ENABLED,


### PR DESCRIPTION
This is basically a continuation of #121. 

The old pipeline was _always_ running with mysql 8.0 because the tests were connecting to `mysql` running in the ubunut host, and not the `mysql` running in the docker container.

Since I could not find a way how to set up the mysql container with a custom config (needed to enable the binlog), I used this [mysql setup action](https://github.com/marketplace/actions/actions-setup-mysql) which offers the possibility to set up custom config values.

Furthermore I had to adapt the query checking if the binlog was enabled if running with mysql 8.4 because `SHOW MASTER STATS` is no longer supported. A good way to confirm that the tests are actually running with the specified mysql versions.