### PR TITLE
Add missing MySQL 8.0+ binlog event types (36-42)

### DIFF
--- a/src/MySQLReplication/Definitions/ConstEventType.php
+++ b/src/MySQLReplication/Definitions/ConstEventType.php
@@ -57,6 +57,15 @@ enum ConstEventType: int
     case MARIA_UPDATE_ROWS_COMPRESSED_EVENT = 170;
     case MARIA_GTID_EVENT = 162;
 
+    // MySQL 8.0+ event types
+    case TRANSACTION_CONTEXT_EVENT = 36;
+    case VIEW_CHANGE_EVENT = 37;
+    case XA_PREPARE_LOG_EVENT = 38;
+    case PARTIAL_UPDATE_ROWS_EVENT = 39;
+    case TRANSACTION_PAYLOAD_EVENT = 40;
+    case HEARTBEAT_LOG_EVENT_V2 = 41;
+    case GTID_TAGGED_LOG_EVENT = 42;
+
     //Transaction ID for 2PC, written whenever a COMMIT is expected.
 
     // Row-Based Binary Logging

--- a/src/MySQLReplication/Event/EventInfo.php
+++ b/src/MySQLReplication/Event/EventInfo.php
@@ -28,7 +28,7 @@ class EventInfo implements JsonSerializable
             $this->binLogCurrent->setBinLogPosition($pos);
         }
         $this->sizeNoHeader = $this->dateTime = null;
-        $this->typeName = ConstEventType::from($this->type)->name;
+        $this->typeName = ConstEventType::tryFrom($this->type)?->name;
     }
 
     public function getTypeName(): ?string


### PR DESCRIPTION
## Problem

The `ConstEventType` enum is missing all event types added in MySQL 8.0+ (types 36–42), causing a `ValueError` crash when the library encounters any of them:

```
[ValueError]
39 is not a valid backing value for enum MySQLReplication\Definitions\Const\EventType
```

The most commonly triggered one is `PARTIAL_UPDATE_ROWS_EVENT` (type 39), which MySQL emits when [`binlog_row_value_options=PARTIAL_JSON`](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_row_value_options) is enabled — a common optimization for tables with JSON columns.

Another likely trigger is `TRANSACTION_PAYLOAD_EVENT` (type 40), emitted when [`binlog_transaction_compression`](https://dev.mysql.com/doc/refman/8.4/en/binary-log-transaction-compression.html) is enabled.

The crash occurs in `EventInfo::__construct()` where `ConstEventType::from()` is called with an unrecognized type value.

### Current workaround (lossy)

Users can disable the MySQL settings that emit these events (`binlog_row_value_options=` and `binlog_transaction_compression=OFF`), but this means MySQL falls back to writing full row images — losing the binlog space savings these features provide. More importantly, without this fix there is no way to use these MySQL features with this library at all.

## Changes

1. **Added all missing MySQL 8.0+ event types** to `ConstEventType`, per [`binlog_event.h`](https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/libs/mysql/binlog/event/binlog_event.h#L285):

   | Type | Name | Trigger |
   |------|------|---------|
   | 36 | `TRANSACTION_CONTEXT_EVENT` | Group Replication |
   | 37 | `VIEW_CHANGE_EVENT` | Group Replication |
   | 38 | `XA_PREPARE_LOG_EVENT` | XA transactions |
   | 39 | `PARTIAL_UPDATE_ROWS_EVENT` | `binlog_row_value_options=PARTIAL_JSON` |
   | 40 | `TRANSACTION_PAYLOAD_EVENT` | `binlog_transaction_compression=ON` |
   | 41 | `HEARTBEAT_LOG_EVENT_V2` | MySQL 8.0.26+ heartbeat |
   | 42 | `GTID_TAGGED_LOG_EVENT` | Tagged GTIDs |

2. **Changed `from()` to `tryFrom()`** in `EventInfo` — so any future unrecognized event types are handled gracefully instead of crashing. The event will be silently skipped by `Event::makeEvent()` which already returns `null` for unhandled types.

> **Note:** This PR adds the event types to the enum so they don't crash, but does not add handlers for them (e.g. decompressing `TRANSACTION_PAYLOAD_EVENT` or parsing partial JSON diffs from `PARTIAL_UPDATE_ROWS_EVENT`). These events are silently skipped by `Event::makeEvent()`. Full handler support could be added in follow-up PRs.

## Why CI doesn't catch this

The test workflow's `my-cnf` only sets `binlog_format=row` and `binlog_rows_query_log_events=ON`. It does not enable `binlog_row_value_options=PARTIAL_JSON` or `binlog_transaction_compression=ON`, so MySQL never emits event types 39/40 during CI. These are common production settings.