### PR TITLE
Support Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "doctrine/dbal": "^4.0",
     "psr/log": "^3.0",
     "psr/simple-cache": "^3.0",
-    "symfony/event-dispatcher": "^6.0|^7.0"
+    "symfony/event-dispatcher": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.19",


### PR DESCRIPTION
This pull request makes a minor update to the `composer.json` file to expand the supported versions of a dependency.

- Dependency compatibility:
  * Updated the version constraint for `symfony/event-dispatcher` to also allow version 8.x, in addition to previously supported versions.