### PR TITLE
Support MySQL 9.0 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
         matrix:
             php: [ '8.2', '8.3', '8.4' ]
-            mysql-version: [ '5.7', '8.0', '8.4' ]
+            mysql-version: [ '5.7', '8.0', '8.4', '9.0' ]
 
     steps:
       - name: Checkout

--- a/src/MySQLReplication/Repository/MySQLRepository.php
+++ b/src/MySQLReplication/Repository/MySQLRepository.php
@@ -67,7 +67,7 @@ readonly class MySQLRepository implements RepositoryInterface, PingableConnectio
     {
         $query = 'SHOW MASTER STATUS';
 
-        if (str_starts_with($this->getVersion(), '8.4')) {
+        if (version_compare($this->getVersion(), '8.4.0') >= 0) {
             $query = 'SHOW BINARY LOG STATUS';
         }
 


### PR DESCRIPTION
I have added MySQL 9.0 to the CI and after the pipeline failed with just a single test i found out that the version constraint in `src/MySQLReplication/Repository/MySQLRepository.php` was checked using a string constraint while in `src/MySQLReplication/BinLog/BinLogSocketConnect.php` there was `version_compare` utilized for versions higher then MySQL 7. So i took over this comparison and everything seems compatible with the newer MySQL version. 

Wanted to try with MySQL 9.6 but MySQL 9.0 is the latest version supported by the CI action `shogo82148/actions-setup-mysql`. But surely this is also a step forward for people utilizing the latest versions 😄 